### PR TITLE
[FIX] store access token in cookie

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -89,7 +89,7 @@ export class AuthController {
   async logout(@getUser() user: UserEntity, @Res() res: Response) {
     this.authLogger.verbose('[GET] /logout');
 
-    return await this.authService.logout(user, res);
+    return await this.authService.logout(res);
   }
 
   @Get('/refresh')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -16,8 +16,11 @@ export class AuthService {
   async createAccessToken(ftUser: FtUserDto, res: Response) {
     const payload = { id: ftUser.id };
     const token = await this.jwtService.signAsync(payload, { expiresIn: '2h' });
-
-    res.header('Authorization', `Bearer ${token}`);
+    res.cookie('accessToken', token, {
+      domain: '	localhost',
+      path: '/',
+      httpOnly: true,
+    });
     console.log(token);
     return token;
   }
@@ -29,13 +32,11 @@ export class AuthService {
       path: '/',
       httpOnly: true,
     });
-    await this.userRepository.saveRefreshToken(token, user);
   }
 
-  async logout(user: UserEntity, res: Response) {
+  async logout(res: Response) {
+    res.cookie('accessToken', '');
     res.cookie('refreshToken', '');
-    user.refreshToken = '';
-    await this.userRepository.save(user);
     return res.redirect('http://localhost:4000/login');
   }
 

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -14,9 +14,6 @@ export class UserEntity {
   @Column({ length: 60, nullable: true })
   email: string;
 
-  @Column({ nullable: true })
-  refreshToken: string;
-
   @Column({ length: 60, nullable: true })
   twoFactorAuthCode: string;
 

--- a/src/users/repository/user.repository.ts
+++ b/src/users/repository/user.repository.ts
@@ -40,11 +40,6 @@ export class UserRepository extends Repository<UserEntity> {
     return user;
   }
 
-  async saveRefreshToken(token: string, user: UserEntity): Promise<void> {
-    user.refreshToken = token;
-    this.save(user);
-  }
-
   async saveTwoFactorAuthCode(user: UserEntity, secret: string): Promise<void> {
     user.twoFactorAuthCode = secret;
     this.save(user);


### PR DESCRIPTION
- access token을 쿠키에 저장
- user entity에 refresh token 삭제

(#13)