### PR TITLE
[FEAT] chat-room entity에 admin column 생성

### DIFF
--- a/src/chat-room/chat-room.module.ts
+++ b/src/chat-room/chat-room.module.ts
@@ -11,6 +11,7 @@ import { MessageEntity } from './entities/message.entity';
 import { ChatRoomValidation } from './chat-room.validation';
 import { DirectMessageEntity } from './entities/directMessage.entity';
 import { DirectMessageRepository } from './repository/directMessage.repository';
+import { MuteUserEntity } from './entities/muteUser.entity';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { DirectMessageRepository } from './repository/directMessage.repository';
       ChatRoomEntity,
       MessageEntity,
       DirectMessageEntity,
+      MuteUserEntity,
     ]),
     AuthModule,
     UsersModule,

--- a/src/chat-room/chat-room.validation.ts
+++ b/src/chat-room/chat-room.validation.ts
@@ -76,6 +76,15 @@ export class ChatRoomValidation {
     return chatRoom;
   }
 
+  async validateChatRoomAdmin(client: Socket): Promise<ChatRoomEntity> {
+    const chatRoom = await this.validateUserInChatRoom(client);
+
+    if (!chatRoom.admin.includes(client.data.user)) {
+      throw new WsException('User is not admin of chat room');
+    }
+    return chatRoom;
+  }
+
   async validateCreateChatRoom(client: Socket, chatRoomName: string) {
     await this.validateUserInLobby(client);
     const isDuplicatedName = await this.chatRoomService.getChatRoomByName(

--- a/src/chat-room/entities/chatRoom.entity.ts
+++ b/src/chat-room/entities/chatRoom.entity.ts
@@ -9,6 +9,7 @@ import {
 } from 'typeorm';
 import { ChatRoomType } from '../enum/chat-room-type.enum';
 import { MessageEntity } from './message.entity';
+import { MuteUserEntity } from './muteUser.entity';
 
 @Entity({ name: 'chat_rooms' })
 export class ChatRoomEntity {
@@ -31,6 +32,9 @@ export class ChatRoomEntity {
   })
   owner: UserEntity;
 
+  @OneToMany(() => UserEntity, (user) => user.id)
+  admin: UserEntity[];
+
   @OneToMany(() => MessageEntity, (message) => message.chatRoom)
   messages: MessageEntity[];
 
@@ -39,6 +43,8 @@ export class ChatRoomEntity {
   bannedUsers: UserEntity[];
 
   @Exclude()
-  @OneToMany(() => UserEntity, (user) => user.id, { nullable: true })
-  mutedUsers: UserEntity[];
+  @OneToMany(() => MuteUserEntity, (muteUser) => muteUser.chatRoom, {
+    nullable: true,
+  })
+  mutedUsers: MuteUserEntity[];
 }

--- a/src/chat-room/entities/directMessage.entity.ts
+++ b/src/chat-room/entities/directMessage.entity.ts
@@ -13,10 +13,10 @@ export class DirectMessageEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => UserEntity, (user) => user.id)
+  @ManyToOne(() => UserEntity, (user) => user.id, { eager: true })
   user1: UserEntity;
 
-  @ManyToOne(() => UserEntity, (user) => user.id)
+  @ManyToOne(() => UserEntity, (user) => user.id, { eager: true })
   user2: UserEntity;
 
   @OneToMany(() => MessageEntity, (message) => message.directMessage)

--- a/src/chat-room/entities/muteUser.entity.ts
+++ b/src/chat-room/entities/muteUser.entity.ts
@@ -1,0 +1,20 @@
+import { UserEntity } from 'src/users/entities/user.entity';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { ChatRoomEntity } from './chatRoom.entity';
+
+@Entity({ name: 'muted_users' })
+export class MuteUserEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => UserEntity, (user) => user.id, { onDelete: 'CASCADE' })
+  user: UserEntity;
+
+  @ManyToOne(() => ChatRoomEntity, (chatRoom) => chatRoom.mutedUsers, {
+    onDelete: 'CASCADE',
+  })
+  chatRoom: ChatRoomEntity;
+
+  @Column()
+  date: Date;
+}


### PR DESCRIPTION
- admin column 생성, owner가 admin 지정가능
- admin이 user mute, ban, kick 가능
- mute는 toggle형식이 아닌 일정기간(5분)동안 mute 상태로 유지

(#70)